### PR TITLE
fix the iOS build generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ However, since the wrapper is open source, you can add the features you need on 
 - [Licensing](#licensing)
 - [Requirements](#requirements)
 - [Quickstart with the sample application](#quickstart-with-the-sample-application)
+  - [Android sample application](#android-sample-application)
+    - [On an emulator](#on-an-emulator)
+    - [On a physical device via USB](#on-a-physical-device-via-usb)
+  - [iOS sample application](#ios-sample-application)
 - [Plugin integration](#plugin-integration)
 - [Plugin usage](#plugin-usage)
 - [Plugin specifics](#plugin-specifics)
@@ -72,19 +76,49 @@ cd blinkcard-react-native && ./initBlinkCardReactNativeSample.sh
 
 **Running the sample application on Android**
 
-For running the sample application on Android, execute the following command:
+## <a name="android-sample-application"></a> Android sample application
+
+### <a name="on-an-emulator"></a> On an emulator:
+
+Simply execute the following command:
+
+```bash
+npx react-native start
+```
+
+Then in another terminal, run:
 
 ```bash
 npx react-native run-android
 ```
 
-**Note:** the plugin can be run directly via Android Studio as well:
+**Alternative: Run directly via Android Studio:**
 
 1. Execute the following command:
 ```bash
 npx react-native start
 ```
 2. Open the `android` folder via Android Studio in the `BlinkCardSample` folder to run the Android sample application.
+
+### <a name="on-a-physical-device-via-usb"></a> On a physical device via USB:
+
+1. Connect your device via USB and enable USB debugging in Developer Options.
+2. Forward the Metro bundler port:
+```bash
+adb reverse tcp:8081 tcp:8081
+```
+3. Start Metro in one terminal:
+```bash
+npx react-native start
+```
+4. In another terminal, build and run on the device:
+```bash
+npx react-native run-android
+```
+
+or open it in Android Studio and run it on the physical device from there.
+
+## <a name="ios-sample-application"></a> iOS sample application
 
 **Running the sample application on iOS**
 

--- a/initBlinkCardReactNativeSample.sh
+++ b/initBlinkCardReactNativeSample.sh
@@ -42,7 +42,7 @@ if [ "$IS_LOCAL_BUILD" = true ]; then
 else
   # Download BlinkCard React Native via NPM
   echo "Downloading blinkcard-react-native module"
-  npm i --save @microblink/blinkcar-react-native
+  npm i --save @microblink/blinkcard-react-native
 fi
 
 # React-native-image-picker plugin needed only for sample application with DirectAPI to get the document images
@@ -54,6 +54,17 @@ pushd android || exit 1
 # Patch the build.gradle to add "maven { url https://maven.microblink.com }"" repository
 perl -i~ -pe "BEGIN{$/ = undef;} s/maven \{/maven \{ url 'https:\\/\\/maven.microblink.com' }\n        maven {/" build.gradle
 
+# Fix node/npx path resolution for Android Studio (Gradle daemon doesn't inherit shell PATH)
+# Use process.execPath to get the real node binary path, not a symlink that the JVM may fail to resolve
+NODE_EXEC=$(node -e "console.log(process.execPath)")
+NODE_DIR=$(dirname "$NODE_EXEC")
+
+# Patch settings.gradle to use the full npx path for autolinking
+sed -i '' "s|ex.autolinkLibrariesFromCommand()|ex.autolinkLibrariesFromCommand([\"$NODE_DIR/npx\", \"@react-native-community/cli\", \"config\"])|" settings.gradle
+
+# Patch app/build.gradle to use the full node path for codegen and bundling
+sed -i '' "s|// nodeExecutableAndArgs = \[\"node\"\]|nodeExecutableAndArgs = [\"$NODE_DIR/node\"]|" app/build.gradle
+
 # Return from the android project folder
 popd
 
@@ -62,6 +73,33 @@ pushd ios || exit 1
 
 # Force minimal iOS version
 sed -i '' "s/platform :ios, min_ios_version_supported/platform :ios, '16.0'/" Podfile
+
+# Fix fmt compilation errors with newer Xcode/Clang:
+# React Native 0.82 uses C++20, which causes the fmt library to use a C++20 feature called
+# 'consteval' that doesn't work reliably on iOS. By compiling just the fmt pod with C++17,
+# fmt disables consteval and uses a compatible fallback instead. The rest of the app still
+# uses C++20. This is like using a different NDK C++ standard for a single native library.
+python3 << 'PYEOF'
+with open('Podfile', 'r') as f:
+    content = f.read()
+
+fmt_fix = """
+    installer.pods_project.targets.each do |target|
+      if target.name == 'fmt'
+        target.build_configurations.each do |config|
+          config.build_settings['CLANG_CXX_LANGUAGE_STANDARD'] = 'gnu++17'
+        end
+      end
+    end
+"""
+
+old = "      # :ccache_enabled => true\n    )\n  end\nend"
+new = "      # :ccache_enabled => true\n    )" + fmt_fix + "  end\nend"
+content = content.replace(old, new)
+
+with open('Podfile', 'w') as f:
+    f.write(content)
+PYEOF
 
 # Add the camera and photo usage descriptions into Info.plist to enable camera scanning and the image upload via gallery
 sed -i '' '/<dict>/a\


### PR DESCRIPTION
## iOS demo app

<img width="414" height="896" alt="blinkcard_rn_ios" src="https://github.com/user-attachments/assets/3ea05515-50be-4a9a-b27d-3e00c1a1baa8" />


## Android demo app

<img width="540" height="1200" alt="blinkcard_rn_android" src="https://github.com/user-attachments/assets/489d7d0f-64c4-4a6c-af82-66f2fe4471f3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect package installation in the sample setup script so the React Native module installs correctly.
  * Resolved Android build issues by ensuring the real Node binary is used for Gradle autolinking and bundling.
  * Mitigated iOS build failures by forcing a compatible C++ standard for affected dependencies.

* **Documentation**
  * Expanded Quickstart with separate Android and iOS sample app guides and detailed Android run instructions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/microblink/blinkcard-react-native/pull/21?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->